### PR TITLE
Ignore spirv::Op::ModuleProcessed in the loader

### DIFF
--- a/rspirv/dr/loader.rs
+++ b/rspirv/dr/loader.rs
@@ -174,6 +174,9 @@ impl binary::Consumer for Loader {
                     .blocks
                     .push(self.block.take().unwrap())
             }
+            spirv::Op::ModuleProcessed => {
+                // Ignore
+            }
             _ => {
                 if_ret_err!(self.block.is_none(), DetachedInstruction);
                 self.block.as_mut().unwrap().instructions.push(inst)


### PR DESCRIPTION
OpModuleProcessed is causing the loader to report `DetachedInstruction` errors. Those are only used for debug purposes, and should be safe to ignore.